### PR TITLE
Get test meetings

### DIFF
--- a/lametro/people.py
+++ b/lametro/people.py
@@ -138,13 +138,10 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
         for body in self.bodies():
             body_types_list = [
                 body_types['Committee'],
-                body_types['Committee (SAP)'],
                 body_types['Independent Taxpayer Oversight Committee'],
-                body_types['Primary Legislative Body'],
-                body_types['Primary Legislative Body (SAP)'],
             ]
 
-            if body['BodyTypeId'] in body_types_list:
+            if (body['BodyTypeId'] in body_types_list) or ('test' in body['BodyName'].lower()):
                 organization_name = body['BodyName'].strip()
 
                 o = Organization(organization_name,

--- a/lametro/people.py
+++ b/lametro/people.py
@@ -136,11 +136,25 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
             members[member] = p
 
         for body in self.bodies():
-            if body['BodyTypeId'] in (body_types['Committee'], body_types['Independent Taxpayer Oversight Committee']):
+            body_types_list = [
+                body_types['Committee'],
+                body_types['Committee (SAP)'],
+                body_types['Independent Taxpayer Oversight Committee'],
+                body_types['Primary Legislative Body'],
+                body_types['Primary Legislative Body (SAP)'],
+            ]
+
+            if body['BodyTypeId'] in body_types_list:
                 organization_name = body['BodyName'].strip()
-                o = Organization(organization_name,
-                                 classification='committee',
-                                 parent_id={'name' : 'Board of Directors'})
+
+                if body['BodyName'] in ('Primary Legislative Body', 'Primary Legislative Body (SAP)'):
+                    o = Organization(organization_name,
+                                    classification='legislature',
+                                    parent_id={'name' : 'Board of Directors'})
+                else :
+                    o = Organization(organization_name,
+                                    classification='committee',
+                                    parent_id={'name' : 'Board of Directors'})
 
                 organization_info = web_info.get(organization_name, {})
                 organization_url = organization_info.get('url', self.WEB_URL + 'https://metro.legistar.com/Departments.aspx')

--- a/lametro/people.py
+++ b/lametro/people.py
@@ -147,14 +147,9 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
             if body['BodyTypeId'] in body_types_list:
                 organization_name = body['BodyName'].strip()
 
-                if body['BodyName'] in ('Primary Legislative Body', 'Primary Legislative Body (SAP)'):
-                    o = Organization(organization_name,
-                                    classification='legislature',
-                                    parent_id={'name' : 'Board of Directors'})
-                else :
-                    o = Organization(organization_name,
-                                    classification='committee',
-                                    parent_id={'name' : 'Board of Directors'})
+                o = Organization(organization_name,
+                                classification='committee',
+                                parent_id={'name' : 'Board of Directors'})
 
                 organization_info = web_info.get(organization_name, {})
                 organization_url = organization_info.get('url', self.WEB_URL + 'https://metro.legistar.com/Departments.aspx')


### PR DESCRIPTION
## Overview

As per [`la-metro-councilmatic` issue #492](https://github.com/Metro-Records/la-metro-councilmatic/issues/942), new meeting body types have been created, but were not being included by the scraper. This brings those in.

## Testing Instructions
- Run the scraper as normal
- Check to see if those new meeting bodies were included