### PR TITLE
Update Caltrans spelling

### DIFF
--- a/lametro/__init__.py
+++ b/lametro/__init__.py
@@ -56,7 +56,7 @@ class Lametro(Jurisdiction):
         )
 
         org.add_post(
-            "District 7 Director, California Department of Transportation (CalTrans), Appointee of the Governor of California",
+            "District 7 Director, California Department of Transportation (Caltrans), Appointee of the Governor of California",
             "Nonvoting Board Member",
             division_id="ocd-division/country:us/state:ca/transit:caltrans/district:7",
         )


### PR DESCRIPTION
## Overview

This PR corrects the spelling of the District 7 Caltrans post. The post in Legistar has been updated from `CalTrans` to `Caltrans`.

Connects Metro-Records/la-metro-councilmatic#1056

## Testing instructions

Verify that `docker-compose run --rm scrapers pupa update lametro people --rpm=0` completes without error