### PR TITLE
Send duplicate agenda item exception to Sentry

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -362,8 +362,8 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                                 legistar_api_url=legistar_api_url,
                             )
                         )
-                except ValueError as e:
-                    capture_exception(e)
+                except ValueError as dupe_item_exc:
+                    capture_exception(dupe_item_exc)
 
 
             e.add_participant(name=body_name, type="organization")

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -1,6 +1,8 @@
 import datetime
 import logging
 
+from sentry_sdk import capture_exception
+
 from legistar.events import LegistarAPIEventScraper
 from pupa.scrape import Event, Scraper
 from legistar.base import LegistarScraper
@@ -342,23 +344,27 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                     ]
 
                 # Historically, the Legistar system has duplicated the EventItemAgendaSequence,
-                # resulting in data inaccuracies. The scrape should fail in such cases, until Metro
-                # cleans the data.
-                item_agenda_sequences = [
-                    item["extras"]["item_agenda_sequence"] for item in e.agenda
-                ]
-                if len(item_agenda_sequences) != len(set(item_agenda_sequences)):
-                    error_msg = "An agenda has duplicate agenda items on the Legistar grid: \
-                        {event_name} on {event_date} ({legistar_api_url}). \
-                        Contact Metro, and ask them to remove the duplicate EventItemAgendaSequence."
+                # resulting in data inaccuracies. In such cases, we'll log the event
+                # and notify Metro that their data needs to be cleaned (rather than failing).
+                try:
+                    item_agenda_sequences = [
+                        item["extras"]["item_agenda_sequence"] for item in e.agenda
+                    ]
+                    if len(item_agenda_sequences) != len(set(item_agenda_sequences)):
+                        error_msg = "An agenda has duplicate agenda items on the Legistar grid: \
+                            {event_name} on {event_date} ({legistar_api_url}). \
+                            Contact Metro, and ask them to remove the duplicate EventItemAgendaSequence."
 
-                    raise ValueError(
-                        error_msg.format(
-                            event_name=e.name,
-                            event_date=e.start_date.strftime("%B %d, %Y"),
-                            legistar_api_url=legistar_api_url,
+                        raise ValueError(
+                            error_msg.format(
+                                event_name=e.name,
+                                event_date=e.start_date.strftime("%B %d, %Y"),
+                                legistar_api_url=legistar_api_url,
+                            )
                         )
-                    )
+                except ValueError as e:
+                    capture_exception(e)
+
 
             e.add_participant(name=body_name, type="organization")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,3 @@ def public_private_bill_data(request):
     marked as having a 'restricted view,' i.e., private vs. public.
     '''
     return request.param
-
-@pytest.fixture
-def mocked_sentry_exception(mocker):
-    mocker.patch('lametro.events.capture_exception', autospec=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,3 +127,7 @@ def public_private_bill_data(request):
     marked as having a 'restricted view,' i.e., private vs. public.
     '''
     return request.param
+
+@pytest.fixture
+def mocked_sentry_exception(mocker):
+    mocker.patch('lametro.events.capture_exception', autospec=True)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -74,13 +74,17 @@ def test_sequence_duplicate_error(event_scraper,
                 raised_exc = sentry_capture.call_args[0][0]
                 assert isinstance(raised_exc, DuplicateAgendaItemException)
 
+                # Make sure the error message we send is useful
                 error_msg = str(raised_exc)
-                legistar_api_url = f"{LametroEventScraper.BASE_URL}/events/{api_event['EventId']}"
+                legistar_api_url = (
+                    f"{LametroEventScraper.BASE_URL}/events/{api_event['EventId']}"
+                )
                 assert legistar_api_url in error_msg
                 assert event.name in error_msg
         else:
             for event in event_scraper.scrape():
                 assert len(event.agenda) == 2
+
 
 def test_events_paired(event_scraper, api_event, web_event, mocker):
     # Create a matching SAP event with a distinct ID

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -36,46 +36,6 @@ def test_status_assignment(event_scraper,
             assert event.status == scraper_assigned_status
 
 
-@pytest.mark.parametrize('item_sequence,should_error', [
-    (12, True),
-    (11, False),
-])
-def test_sequence_duplicate_error(event_scraper,
-                                  api_event,
-                                  web_event,
-                                  event_agenda_item,
-                                  item_sequence,
-                                  should_error,
-                                  mocker):
-    with requests_mock.Mocker() as m:
-        matcher = re.compile('webapi.legistar.com')
-        m.get(matcher, json={}, status_code=200)
-
-        matcher = re.compile('metro.legistar.com')
-        m.get(matcher, json={}, status_code=200)
-
-        api_event['event_details'] = [{'note': 'web',
-                                      'url': 'https://metro.legistar.com/MeetingDetail.aspx?ID=642118&GUID=F19B2133-928C-4390-9566-C293C61DC89A&Options=info&Search='}]
-
-        event_agenda_item_b = event_agenda_item.copy()
-        event_agenda_item_b['EventItemAgendaSequence'] = item_sequence
-
-        mocker.patch('lametro.LametroEventScraper._merge_events', return_value=[(api_event, LAMetroWebEvent(web_event))])
-        mocker.patch('lametro.LametroEventScraper.agenda', return_value=[event_agenda_item, event_agenda_item_b])
-
-        if should_error:
-            with pytest.raises(ValueError) as excinfo:
-                for event in event_scraper.scrape():
-                    assert 'An agenda has duplicate agenda items on the Legistar grid'\
-                           .format(api_event['EventId'])\
-                           in str(excinfo.value)
-
-                    assert event['EventBodyName'] in str(excinfo.value)
-        else:
-            for event in event_scraper.scrape():
-                assert len(event.agenda) == 2
-
-
 def test_events_paired(event_scraper, api_event, web_event, mocker):
     # Create a matching SAP event with a distinct ID
     sap_api_event = api_event.copy()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -36,6 +36,46 @@ def test_status_assignment(event_scraper,
             assert event.status == scraper_assigned_status
 
 
+@pytest.mark.parametrize('item_sequence,should_error', [
+    (12, True),
+    (11, False),
+])
+def test_sequence_duplicate_error(event_scraper,
+                                  api_event,
+                                  web_event,
+                                  event_agenda_item,
+                                  item_sequence,
+                                  should_error,
+                                  mocker):
+    with requests_mock.Mocker() as m:
+        matcher = re.compile('webapi.legistar.com')
+        m.get(matcher, json={}, status_code=200)
+
+        matcher = re.compile('metro.legistar.com')
+        m.get(matcher, json={}, status_code=200)
+
+        api_event['event_details'] = [{'note': 'web',
+                                      'url': 'https://metro.legistar.com/MeetingDetail.aspx?ID=642118&GUID=F19B2133-928C-4390-9566-C293C61DC89A&Options=info&Search='}]
+
+        event_agenda_item_b = event_agenda_item.copy()
+        event_agenda_item_b['EventItemAgendaSequence'] = item_sequence
+
+        mocker.patch('lametro.LametroEventScraper._merge_events', return_value=[(api_event, LAMetroWebEvent(web_event))])
+        mocker.patch('lametro.LametroEventScraper.agenda', return_value=[event_agenda_item, event_agenda_item_b])
+
+        if should_error:
+            with pytest.raises(ValueError) as excinfo:
+                for event in event_scraper.scrape():
+                    assert 'An agenda has duplicate agenda items on the Legistar grid'\
+                           .format(api_event['EventId'])\
+                           in str(excinfo.value)
+
+                    assert event['EventBodyName'] in str(excinfo.value)
+        else:
+            for event in event_scraper.scrape():
+                assert len(event.agenda) == 2
+
+
 def test_events_paired(event_scraper, api_event, web_event, mocker):
     # Create a matching SAP event with a distinct ID
     sap_api_event = api_event.copy()


### PR DESCRIPTION
# Overview

See title.

Connects #14 

## Notes

I made an explicit `DuplicateAgendaItemsException` class, which I think improves readability and makes scraper behavior and Sentry integration easier to test. I think this can be a good pattern moving forward as we leverage Sentry alerts.