### PR TITLE
Classify Special Board Budget Workshop as committee

### DIFF
--- a/lametro/__init__.py
+++ b/lametro/__init__.py
@@ -122,7 +122,7 @@ class Lametro(Jurisdiction):
         )
         yield org
 
-        org = Organization(name="Special Board Budget Workshop", classification="legislature")
+        org = Organization(name="Special Board Budget Workshop", classification="committee")
 
         org.add_source("https://metro.legistar.com/DepartmentDetail.aspx?ID=52282&GUID=2FFCEDD3-18CA-4895-9998-8F9A2F533E4F&R=5c9ccace-e519-461a-9c62-aa987ea49f67")
         


### PR DESCRIPTION
## Overview

The PR classifies the `Special Board Budget Workshop` as a `committee`. We classified it as a `legislature` in #18 but `pupa` expects only one `legislature`, which caused the people scrape to fail.

Connects #17 

## Testing Instructions

- Verify that `docker-compose run --rm app scrapers pupa update lametro people` runs without error

After this is merged, I'll go in to the staging Councilmatic instance and manually set `Special Board Budget Workshop`'s classfication to `committee`. Then, I'll re-run the full scrape.