### PR TITLE
Account for multiple minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Build containers and run tests
-        run: docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm scrapers
+        run: docker compose -f docker-compose.yml -f tests/docker-compose.yml run --rm scrapers

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL maintainer "DataMade <info@datamade.us>"
 ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && \
-    apt-get install -y libxml2-dev libxslt1-dev gdal-bin gnupg git-core && \
+    apt-get install -y libxml2-dev libxslt1-dev gdal-bin gnupg git-core tesseract-ocr && \
     apt-get clean && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -18,39 +18,6 @@ To publish a `production` tag of the scraper image, sync the `main` branch with 
 git push origin main:deploy
 ```
 
-### Testing locally with councilmatic
-
-In order to test what you have locally with your local dev instance of councilmatic, make two small temporary changes to councilmatic's docker-compose and Dockerfile.
-
-For the **docker-compose**, comment out the remote image to start. Then have the scrapers build from the Dockerfile within this repo, while changing the context to be able to find this. The example below works if your scrapers repo lives in the same directory as your councilmatic repo:
-
-```yml
-# docker-compose.yml
-
-scrapers:
-    # image: ghcr.io/metro-records/scrapers-lametro:deploy
-    build:
-      dockerfile: Dockerfile
-      context: ../scrapers-lametro
-      ...
-```
-
-Now that the context has changed to be able to find this repo, add a line to the **Dockerfile** to copy its contents into the container:
-
-```docker
-# Dockerfile
-
-COPY ./requirements.txt /app/requirements.txt
-
-COPY ./scrapers-lametro /app/scrapers-lametro
-# ^^^ new line
-
-RUN pip install pip==24.0 && \
-...
-```
-
-Run `docker-compose build app` to rebuild the councilmatic container with these scrapers. Now you'll be able to use your scraper commands on that container and have your local dev scrapers handle them!
-
 ### Scheduling
 
 The LA Metro scrapers are scheduled via Airflow. The production Airflow instance

--- a/README.md
+++ b/README.md
@@ -18,6 +18,39 @@ To publish a `production` tag of the scraper image, sync the `main` branch with 
 git push origin main:deploy
 ```
 
+### Testing locally with councilmatic
+
+In order to test what you have locally with your local dev instance of councilmatic, make two small temporary changes to councilmatic's docker-compose and Dockerfile.
+
+For the **docker-compose**, comment out the remote image to start. Then have the scrapers build from the Dockerfile within this repo, while changing the context to be able to find this. The example below works if your scrapers repo lives in the same directory as your councilmatic repo:
+
+```yml
+# docker-compose.yml
+
+scrapers:
+    # image: ghcr.io/metro-records/scrapers-lametro:deploy
+    build:
+      dockerfile: Dockerfile
+      context: ../scrapers-lametro
+      ...
+```
+
+Now that the context has changed to be able to find this repo, add a line to the **Dockerfile** to copy its contents into the container:
+
+```docker
+# Dockerfile
+
+COPY ./requirements.txt /app/requirements.txt
+
+COPY ./scrapers-lametro /app/scrapers-lametro
+# ^^^ new line
+
+RUN pip install pip==24.0 && \
+...
+```
+
+Run `docker-compose build app` to rebuild the councilmatic container with these scrapers. Now you'll be able to use your scraper commands on that container and have your local dev scrapers handle them!
+
 ### Scheduling
 
 The LA Metro scrapers are scheduled via Airflow. The production Airflow instance

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -562,7 +562,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                                 in_mem_image.seek(0)
                                 cover_page_text = pytesseract.image_to_string(Image.open(in_mem_image))
 
-                    if "MINUTES" in cover_page_text:
+                    if "MINUTES" in cover_page_text.upper():
                         valid_attachments.append(attach)
 
         for item in valid_attachments:

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -502,8 +502,13 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
         result = self.search(
             "/matters/",
             "MatterId",
-            "MatterBodyId eq {} and substringof('{}', MatterTitle) and substringof('Minutes', MatterTitle)".format(
-                event["EventBodyId"], date
+            (
+                f"MatterBodyId eq {event["EventBodyId"]} and " +
+                f"substringof('{date}', MatterTitle) and " +
+                "(" +
+                    "(MatterTypeName eq 'Minutes') or " +
+                    "(substringof('Minutes', MatterTitle) and MatterTypeName eq 'Informational Report')" +
+                ")"
             ),
         )
 

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -406,14 +406,15 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
             else:
                 approved_minutes = self.find_approved_minutes(event)
                 if approved_minutes:
-                    e.add_document(
-                        note=approved_minutes["MatterAttachmentName"],
-                        url=approved_minutes["MatterAttachmentHyperlink"],
-                        media_type="application/pdf",
-                        date=self.to_utc_timestamp(
-                            approved_minutes["MatterAttachmentLastModifiedUtc"]
-                        ).date(),
-                    )
+                    for minutes in approved_minutes:
+                        e.add_document(
+                            note=minutes["MatterAttachmentName"],
+                            url=minutes["MatterAttachmentHyperlink"],
+                            media_type="application/pdf",
+                            date=self.to_utc_timestamp(
+                                minutes["MatterAttachmentLastModifiedUtc"]
+                            ).date(),
+                        )
                     e.extras["approved_minutes"] = True
 
             for audio in event["audio"]:
@@ -533,8 +534,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
         if len(attachments) == 0:
             raise ValueError("No attachments for the approved minutes matter")
         else:
-            (attachment,) = [each for each in attachments]
-            return attachment
+            return attachments
 
 
 class LAMetroAPIEvent(dict):

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -532,52 +532,9 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
 
         if len(attachments) == 0:
             raise ValueError("No attachments for the approved minutes matter")
-        elif len(attachments) == 1:
-            return attachments[0]
         else:
-            # This dictionary contains a mapping of dates of events known to
-            # have more than one minutes file attached to the approval matter,
-            # to the name of the attachment representing the correct minutes
-            # file.
-            handled_cases = {
-                "May 28, 2015": "Regular Board Meeting Minutes on May 28, 2015",
-                "September 24, 2020": "LA SAFE Minutes - September 24, 2020",
-                "June 24, 2021": "LA SAFE MINUTES - June 24, 2021",
-                "December 2, 2021": "Regular Board Meeting MINUTES - December 2, 2021",
-                "January 27, 2022": "Regular Board Meeting MINUTES - January 27, 2022",
-                "February 24, 2022": "MINUTES - February 24, 2022 RBM",
-                "June 23, 2022": "Regular Board Meeting MINUTES - June 23, 2022",
-                "December 1, 2022": "Regular Board Meeting MINUTES - December 1, 2022",
-            }
-
-            if date in handled_cases:
-                attachment_name = handled_cases[date]
-                (attachment,) = [
-                    each
-                    for each in attachments
-                    if each["MatterAttachmentName"] == attachment_name
-                ]
-                return attachment
-
-            else:
-                try:
-                    (attachment,) = [
-                        each
-                        for each in attachments
-                        if "minutes" in each["MatterAttachmentName"].lower()
-                    ]
-                except ValueError:
-                    LOGGER.critical(
-                        "More than one attachment for the approved minutes matter"
-                    )
-                else:
-                    msg = (
-                        "More than attachment for minutes matter {0}, using {1}".format(
-                            matter["MatterId"], attachment["MatterAttachmentName"]
-                        )
-                    )
-                    self.info(msg)
-                    return attachment
+            (attachment,) = [each for each in attachments]
+            return attachment
 
 
 class LAMetroAPIEvent(dict):

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -409,16 +409,15 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                 )
             else:
                 approved_minutes = self.find_approved_minutes(event)
-                if approved_minutes:
-                    for minutes in approved_minutes:
-                        e.add_document(
-                            note=minutes["MatterAttachmentName"],
-                            url=minutes["MatterAttachmentHyperlink"],
-                            media_type="application/pdf",
-                            date=self.to_utc_timestamp(
-                                minutes["MatterAttachmentLastModifiedUtc"]
-                            ).date(),
-                        )
+                for minutes in approved_minutes:
+                    e.add_document(
+                        note=minutes["MatterAttachmentName"],
+                        url=minutes["MatterAttachmentHyperlink"],
+                        media_type="application/pdf",
+                        date=self.to_utc_timestamp(
+                            minutes["MatterAttachmentLastModifiedUtc"]
+                        ).date(),
+                    )
                     e.extras["approved_minutes"] = True
 
             for audio in event["audio"]:
@@ -497,7 +496,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
         if name not in {"Board of Directors - Regular Board Meeting", "LA SAFE"}:
             return None
 
-        # if the event is the future, there won't have been a chance to
+        # if the event is in the future, there won't have been a chance to
         # approve the minutes
         if event["start"] > datetime.datetime.now(datetime.timezone.utc):
             return None
@@ -516,63 +515,56 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
             ),
         )
 
-        try:
-            (matter,) = result
-        except ValueError as e:
-            if "not enough values" in str(e):
-                self.warning(
-                    "Couldn't find minutes for the {} meeting of {}.".format(name, date)
-                )
-                return None
-            elif "too many values to unpack" in str(e):
-                self.warning(
-                    "Found more than one minutes file for the {} meeting of {}.".format(
-                        name, date
-                    )
-                )
-                return None
+        # Will print a warning if no minutes have been found
+        valid_attachments = []
+
+        # Sometimes, the search returns more than one board report.
+        # Go through each matter yielded from this generator to account for that.
+        for matter in result:
+            attachment_url = self.BASE_URL + "/matters/{}/attachments".format(
+                matter["MatterId"]
+            )
+
+            attachments = self.get(attachment_url).json()
+
+            if len(attachments) == 0:
+                raise ValueError("No attachments for the approved minutes matter")
+            elif len(attachments) == 1:
+                valid_attachments.append(attachments)
             else:
-                raise
+                """
+                Multiple attachments have been found.
+                Return only those that look like minutes files.
+                """
+                for attach in attachments:
+                    url = attach["MatterAttachmentHyperlink"]
+                    response = requests.get(url)
 
-        attachment_url = self.BASE_URL + "/matters/{}/attachments".format(
-            matter["MatterId"]
-        )
+                    with io.BytesIO(response.content) as filestream:
+                        pdf = pdfplumber.open(filestream)
+                        cover_page = pdf.pages[0]
 
-        attachments = self.get(attachment_url).json()
+                        cover_page_text = cover_page.extract_text()
+                        if not cover_page_text:
+                            # No extractable text found.
+                            # Turn the page into an image and use OCR to get text.
+                            pdf_image = cover_page.to_image(resolution=150)
 
-        if len(attachments) == 0:
-            raise ValueError("No attachments for the approved minutes matter")
-        elif len(attachments) == 1:
-            return attachments
-        else:
-            """
-            Multiple attachments have been found.
-            Return only those that look like minutes files.
-            """
-            valid_attachments = []
-            for attach in attachments:
-                url = attach["MatterAttachmentHyperlink"]
-                response = requests.get(url)
+                            with io.BytesIO() as in_mem_image:
+                                pdf_image.save(in_mem_image)
+                                in_mem_image.seek(0)
+                                cover_page_text = pytesseract.image_to_string(Image.open(in_mem_image))
 
-                with io.BytesIO(response.content) as filestream:
-                    pdf = pdfplumber.open(filestream)
-                    cover_page = pdf.pages[0]
+                    if "MINUTES" in cover_page_text:
+                        valid_attachments.append(attach)
 
-                    cover_page_text = cover_page.extract_text()
-                    if not cover_page_text:
-                        # No extractable text found.
-                        # Turn the page into an image and use OCR to get text.
-                        pdf_image = cover_page.to_image(resolution=150)
-
-                        with io.BytesIO() as in_mem_image:
-                            pdf_image.save(in_mem_image)
-                            in_mem_image.seek(0)
-                            cover_page_text = pytesseract.image_to_string(Image.open(in_mem_image))
-
-                if "MINUTES" in cover_page_text:
-                    valid_attachments.append(attach)
-
-            return valid_attachments
+        for item in valid_attachments:
+            yield item
+        
+        if len(valid_attachments) == 0:
+            self.warning(
+                "Couldn't find minutes for the {} meeting of {}.".format(name, date)
+            )
 
 
 class LAMetroAPIEvent(dict):

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -523,7 +523,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
         )
 
         # Will print a warning if no minutes have been found
-        valid_attachments = []
+        n_minutes = 0
 
         # Sometimes, the search returns more than one board report.
         # Go through each matter yielded from this generator to account for that.
@@ -537,7 +537,8 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
             if len(attachments) == 0:
                 raise ValueError("No attachments for the approved minutes matter")
             elif len(attachments) == 1:
-                valid_attachments.append(attachments)
+                yield attachments[0]
+                n_minutes += 1
             else:
                 """
                 Multiple attachments have been found.
@@ -563,12 +564,10 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                                 cover_page_text = pytesseract.image_to_string(Image.open(in_mem_image))
 
                     if "MINUTES" in cover_page_text.upper():
-                        valid_attachments.append(attach)
+                        yield attach
+                        n_minutes += 1
 
-        for item in valid_attachments:
-            yield item
-        
-        if len(valid_attachments) == 0:
+        if n_minutes == 0:
             self.warning(
                 "Couldn't find minutes for the {} meeting of {}.".format(name, date)
             )

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -502,15 +502,22 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
             return None
 
         date = event["start"].strftime("%B %-d, %Y")
+
+        associated_with_meeting_body = f"MatterBodyId eq {event['EventBodyId']}"
+        meeting_date_in_title = f"substringof('{date}', MatterTitle)"
+        matter_type_minutes = "MatterTypeName eq 'Minutes'"
+        minutes_in_title = "substringof('Minutes', MatterTitle)"
+        matter_type_informational = "MatterTypeName eq 'Informational Report'"
+
         result = self.search(
             "/matters/",
             "MatterId",
             (
-                f"MatterBodyId eq {event['EventBodyId']} and " +
-                f"substringof('{date}', MatterTitle) and " +
+                f"{associated_with_meeting_body} and " +
+                f"{meeting_date_in_title} and " +
                 "(" +
-                    "(MatterTypeName eq 'Minutes') or " +
-                    "(substringof('Minutes', MatterTitle) and MatterTypeName eq 'Informational Report')" +
+                    f"({matter_type_minutes}) or " +
+                    f"({minutes_in_title} and {matter_type_informational})" +
                 ")"
             ),
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ pytest-mock==1.10.1
 requests-mock==1.5.2
 requests[security]
 sentry-sdk
+pdfplumber==0.11.3
+pytesseract==0.3.10


### PR DESCRIPTION
## Overview

This branch is one of two changes needed to resolve #16. In order to associate one meeting with multiple minutes, we're now saving all minutes documents found under each event.

- Connects: #16
- Related councilmatic PR: https://github.com/Metro-Records/la-metro-councilmatic/pull/1154

### Demo

![image](https://github.com/user-attachments/assets/38d4214c-37cf-4b37-9e44-d52cfd9d4754)

### Notes

This should most likely be merged in **after** the corresponding pr in the councilmatic repo since this would introduce a template bug in councilmatic if merged in beforehand..

## Testing Instructions
** Note: this PR will need to be tested locally, since it involves tandem changes with councilmatic. Also, these instructions should be performed in the councilmatic container unless otherwise stated.
 * Pull down this branch, and check the updated README to get this working with the corresponding councilmatic branch.
 * Make the described changes in councilmatic and build the container.
 * Run an events scrape large enough to capture an event with multiple meeting minutes
   * I ran the following command to make sure I got the event described in the issue: `docker-compose run --rm scrapers pupa update lametro events window=180 --rpm=0`. This will take several minutes.
 * Find a meeting with multiple minutes
   * I used the meeting described in the issue.
   * Confirm that the event has multiple minutes files.
