### PR TITLE
Account for restricted matters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL maintainer "DataMade <info@datamade.us>"
 ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && \
-    apt-get install -y libxml2-dev libxslt1-dev gdal-bin gnupg git-core && \
+    apt-get install -y libxml2-dev libxslt1-dev gdal-bin gnupg git-core tesseract-ocr && \
     apt-get clean && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -528,6 +528,12 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
         # Sometimes, the search returns more than one board report.
         # Go through each matter yielded from this generator to account for that.
         for matter in result:
+            if (matter['MatterRestrictViewViaWeb'] or
+            matter['MatterStatusName'] == 'Draft' or
+            matter['MatterBodyName'] == 'TO BE REMOVED'):
+            # Ignore this matter if there are signs that it shouldn't be processed.
+                continue
+
             attachment_url = self.BASE_URL + "/matters/{}/attachments".format(
                 matter["MatterId"]
             )
@@ -569,7 +575,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
 
         if n_minutes == 0:
             self.warning(
-                "Couldn't find minutes for the {} meeting of {}.".format(name, date)
+                f"Couldn't find minutes for the {name} meeting of {date}."
             )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ pytest-mock==1.10.1
 requests-mock==1.5.2
 requests[security]
 sentry-sdk
+pdfplumber==0.11.3
+pytesseract==0.3.10


### PR DESCRIPTION
## Overview

This branch works off of the previous PR #23 to account for matters that should be disallowed. 

When testing #23 on staging, it came across one of the handled cases from September 24, 2020. This case had a **draft** matter that did not have any minutes attached. Because we were just printing a warning and passing through `None`, the scraper didn't have any issues. But now that we're processing all of the handled cases programmatically, this raised an error we had in place.

Since that error was being raised on purpose, I figured that keeping that behavior would be best. So instead, this branch is cribbing from a conditional in the bills scraper that skips over any "restricted" bills. Ultimately, this means that now for events, we'll either be skipping any matters that look like they should be skipped, raising an error if an approved matter does not have any attachments at all, or processing the attachments normally to look for minutes.

- Connects: #16
- Connects: #23 

### Notes

Check the new commit for the changes that are different from the rest of the previous pr.

## Testing Instructions
* Run a full event scrape so that it encounters the events previously listed in `handled_cases`
  * `docker-compose run --rm scrapers pupa update lametro events --rpm=0`
  * This will take some time
* Confirm that it completes without error
