### PR TITLE
Report to sentry when pdf syntax errors encountered

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -10,6 +10,7 @@ from pupa.scrape import Event, Scraper
 from legistar.base import LegistarScraper
 
 import pdfplumber
+from pdfminer.pdfparser import PDFSyntaxError
 import pytesseract
 from PIL import Image
 
@@ -555,7 +556,11 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                     response = requests.get(url)
 
                     with io.BytesIO(response.content) as filestream:
-                        pdf = pdfplumber.open(filestream)
+                        try:
+                            pdf = pdfplumber.open(filestream)
+                        except PDFSyntaxError as e:
+                            capture_exception(e)
+                            continue
                         cover_page = pdf.pages[0]
 
                         cover_page_text = cover_page.extract_text()


### PR DESCRIPTION
## Overview

We encountered a `pdfsyntaxerror` during the first scrape after we first merged in #28. This has not happened again at time of writing, but this pr is a small change to report to sentry and keep things moving if we ever do come across that again.

- Connects #16

### Notes

The error:
```
09/25/2024 01:00:30 INFO scrapelib: GET - 'https://webapi.legistar.com/v1/metro/events/2448/eventitems'
09/25/2024 01:00:31 INFO scrapelib: GET - 'https://webapi.legistar.com/v1/metro/matters/'
09/25/2024 01:00:32 INFO scrapelib: GET - 'https://webapi.legistar.com/v1/metro/matters/9112/attachments'
Traceback (most recent call last):
File "/usr/local/bin/pupa", line 8, in <module>
sys.exit(main())
File "/usr/local/lib/python3.10/site-packages/pupa/cli/__main__.py", line 75, in main
subcommands[args.subcommand].handle(args, other)
File "/usr/local/lib/python3.10/site-packages/pupa/cli/commands/update.py", line 334, in handle
return self.do_handle(args, other, juris)
File "/usr/local/lib/python3.10/site-packages/pupa/cli/commands/update.py", line 391, in do_handle
report["scrape"] = self.do_scrape(juris, args, scrapers)
File "/usr/local/lib/python3.10/site-packages/pupa/cli/commands/update.py", line 215, in do_scrape
report[scraper_name] = scraper.do_scrape(**scrape_args)
File "/usr/local/lib/python3.10/site-packages/pupa/scrape/base.py", line 120, in do_scrape
for obj in self.scrape(**kwargs) or []:
File "/app/lametro/events.py", line 412, in scrape
for minutes in approved_minutes:
File "/app/lametro/events.py", line 558, in find_approved_minutes
pdf = pdfplumber.open(filestream)
File "/usr/local/lib/python3.10/site-packages/pdfplumber/pdf.py", line 101, in open
return cls(
File "/usr/local/lib/python3.10/site-packages/pdfplumber/pdf.py", line 47, in __init__
self.doc = PDFDocument(PDFParser(stream), password=password or "")
File "/usr/local/lib/python3.10/site-packages/pdfminer/pdfdocument.py", line 752, in __init__
raise PDFSyntaxError("No /Root object! - Is this really a PDF?")
pdfminer.pdfparser
.PDFSyntaxError
:
No /Root object! - Is this really a PDF?
```

