### PR TITLE
Send pdfsyntaxerrors as warning instead of error

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Overview
+
+Brief description of what this PR does, and why it is needed.
+
+Closes #XXX
+
+### Demo
+
+Optional. Screenshots, `curl` examples, etc.
+
+### Notes
+
+Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+
+## Testing Instructions
+
+ * How to test this PR
+ * Prefer bulleted description
+ * Start after checking out this branch
+ * Include any setup required, such as bundling scripts, restarting services, etc.
+ * Include test case, and expected output

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -3,7 +3,7 @@ import logging
 import requests
 import io
 
-from sentry_sdk import capture_exception
+from sentry_sdk import capture_exception, capture_message
 
 from legistar.events import LegistarAPIEventScraper
 from pupa.scrape import Event, Scraper
@@ -559,7 +559,10 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                         try:
                             pdf = pdfplumber.open(filestream)
                         except PDFSyntaxError as e:
-                            capture_exception(e)
+                            capture_message(
+                                f"PDFPlumber encountered an error opening a file: {e}",
+                                "warning"
+                            )
                             continue
                         cover_page = pdf.pages[0]
 


### PR DESCRIPTION
## Overview

The PDFSyntaxErrors that pdfplumber/pdfminer have been raising have been inconsistent and seem to be temporary issues that resolve themselves on subsequent scraper runs. Because of this, this pr will send sentry reports of this type as warnings instead of errors.

If a specific pdf raises issues multiple times in a row, we can investigate further. The log in Sentry will contain the url of the attachment as well as the matter it came from.

- Closes #31

### Demo
![image](https://github.com/user-attachments/assets/ff1d9888-7a9e-4edc-a3a8-705b50d0c7ee)


## Testing Instructions

 * Pull down this branch
 * Make the scraper manually raise a PDFSyntaxError on the first multi-attachment matter, by inserting the following line after line 560 in events.py
   * `raise PDFSyntaxError("No /Root object! - Is this really a PDF?")`
   * Optionally insert a breakpoint after that new line for an indication in the command line of when the warning should be reported
 * Run an event scrape wide enough to ensure we get a matter with multiple attachments. This may take a few minutes.
   * I've been running `docker-compose run --rm scrapers pupa update lametro events window=100 --rpm=0`
 * Once the run is done or you've hit your breakpoint, check [recently reported issues in Sentry](https://datamade.sentry.io/issues/?project=4504447849201664&statsPeriod=14d) and confirm that the warning is shown as expected.