### PR TITLE
Add scrape schedule to docs

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,3 +1,5 @@
+name: Publish documentation to GitHub Pages
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -24,6 +24,9 @@ jobs:
         if: steps.docs-changed.outputs.any_changed == 'true'
         uses: quarto-dev/quarto-actions/setup@v2
 
+      - name: Install dependencies
+        run: pip install -r docs/requirements.txt
+
       - name: Render and Publish
         if: steps.docs-changed.outputs.any_changed == 'true'
         uses: quarto-dev/quarto-actions/publish@v2

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ venv
 lametro/secrets.py
 
 .DS_Store
+.venv

--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ For more on development, debugging, deployment, and more, [consult the documenta
 ## Updating the documentation
 
 To make changes to the documentation, [install Quarto](https://quarto.org/docs/get-started/).
+
+Next, create a virtual environment, and install the documentation's Python dependencies:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r docs/requirements.txt
+```
+
+(Remember to activate your virtual environment with `source .venv/bin/activate` next time you want to work on the docs!)
+
 Then, run the following in your terminal:
 
 ```bash

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -71,9 +71,11 @@ _dag_config = []
 
 for line in config_file.iter_lines():
     line_str = line.decode("utf-8")
+
     if line_str.startswith("SCRAPING_DAGS"):
         config_start = True
         continue
+
     if config_start:
         _dag_config.append(line_str)
 
@@ -81,9 +83,11 @@ exec("dag_config = {" + "".join(_dag_config))
 
 for dag, conf in dag_config.items():
     print(f"### {dag}")
+
     print(f"_{conf['description']}_\n\n")
     for interval in conf["schedule_interval"]:
         print(f"- {get_description(interval)}\n")
+
     print("\n")
 ```
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -74,14 +74,13 @@ for line in config_file.iter_lines():
 
     if line_str.startswith("SCRAPING_DAGS"):
         config_start = True
-        continue
 
     if config_start:
         _dag_config.append(line_str)
 
-exec("dag_config = {" + "".join(_dag_config))
+exec("".join(_dag_config))
 
-for dag, conf in dag_config.items():
+for dag, conf in SCRAPING_DAGS.items():
     print(f"### {dag}")
 
     print(f"_{conf['description']}_\n\n")

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -27,6 +27,66 @@ outlined below.
 
 See [Deployment](deployment.qmd) for more on how scraper image tags are built.
 
+## When do they run?
+
+::: {.callout-tip}
+See [the Airflow dashboard](https://la-metro-dashboard-heroku-prod.datamade.us/dashboard/) for information
+about the latest and next scraper runs.
+:::
+
+```{python}
+#| echo: false
+import datetime
+import pytz
+
+def get_offset(tz):
+  return abs(int(tz.utcoffset(datetime.datetime.now()).total_seconds() / (60*60)))
+
+ordtz = pytz.timezone("America/Chicago")
+latz = pytz.timezone("America/Los_Angeles")
+```
+
+::: {.callout-tip}
+**Scrape schedules are written in UTC!** 
+
+- Subtract `{python} get_offset(latz)` hours to convert to Los Angeles time.
+- Subtract `{python} get_offset(ordtz)` hours to convert to Chicago time.
+
+Mental math getting you down? [Try World Time Buddy](https://www.worldtimebuddy.com/?pl=1&lid=100,5368361,4887398&h=100&hf=1)!
+:::
+
+```{python}
+#| echo: false
+#| output: asis
+from datetime import timedelta
+import json
+
+from cron_descriptor import get_description
+import requests
+
+config_file = requests.get("https://raw.githubusercontent.com/Metro-Records/la-metro-dashboard/refs/heads/main/dags/config.py")
+
+config_start = False
+_dag_config = []
+
+for line in config_file.iter_lines():
+    line_str = line.decode("utf-8")
+    if line_str.startswith("SCRAPING_DAGS"):
+        config_start = True
+        continue
+    if config_start:
+        _dag_config.append(line_str)
+
+exec("dag_config = {" + "".join(_dag_config))
+
+for dag, conf in dag_config.items():
+    print(f"### {dag}")
+    print(f"_{conf['description']}_\n\n")
+    for interval in conf["schedule_interval"]:
+        print(f"- {get_description(interval)}\n")
+    print("\n")
+```
+
 ## What do they depend on?
 
 The scrapers have a couple of key dependencies.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+jupyter
 requests
 cron-descriptor

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+requests
+cron-descriptor


### PR DESCRIPTION
## Description

This PR adds the scrape schedule to the main page of the documentation. It does this by fetching the DAG config from the dashboard, then parsing the DAGs, their descriptions, and their schedules from that config. That way, we only need to manage the schedules in one place, and we can simply rebuild our docs to reflect any changes.

Handles https://github.com/Metro-Records/la-metro-councilmatic/issues/451

### Testing instructions

- Manually triggered a build. Check out the updated docs at: https://metro-records.github.io/scrapers-lametro/#when-do-they-run