### PR TITLE
Install Councilmatic in pupa settings file

### DIFF
--- a/pupa_settings.py
+++ b/pupa_settings.py
@@ -6,10 +6,7 @@ from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 
 
-sentry_logging = LoggingIntegration(
-    level=logging.INFO,
-    event_level=logging.FATAL
-)
+sentry_logging = LoggingIntegration(level=logging.INFO, event_level=logging.FATAL)
 
 sentry_sdk.init(
     dsn="https://78df3855dad0415e99c3c327ea9f8126:a04d4bfe629a421aa2703a68e71f27dd@o13877.ingest.sentry.io/4504447849201664",
@@ -17,52 +14,44 @@ sentry_sdk.init(
     environment=os.getenv("SENTRY_ENVIRONMENT", "dev"),
 )
 
-CACHE_DIR = '/tmp/cache/_cache'
-SCRAPED_DATA_DIR = '/tmp/cache/_data'
-STATIC_ROOT = '/tmp'
+CACHE_DIR = "/tmp/cache/_cache"
+SCRAPED_DATA_DIR = "/tmp/cache/_data"
+STATIC_ROOT = "/tmp"
 
-DATABASE_URL = os.environ.get('DATABASE_URL', 'postgis://opencivicdata:@localhost/opencivicdata')
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL", "postgis://opencivicdata:@localhost/opencivicdata"
+)
 
-SHARED_DB = os.environ.get('SHARED_DB') == 'True'
-if SHARED_DB:
-    INSTALLED_APPS = (
-        'django.contrib.contenttypes',
-        'opencivicdata.core.apps.BaseConfig',
-        'opencivicdata.legislative.apps.BaseConfig',
-        'pupa',
-        'councilmatic_core'
-    )
-    OCD_CITY_COUNCIL_NAME = None
+INSTALLED_APPS = (
+    "django.contrib.contenttypes",
+    "opencivicdata.core.apps.BaseConfig",
+    "opencivicdata.legislative.apps.BaseConfig",
+    "councilmatic_core",
+    "pupa",
+)
+OCD_CITY_COUNCIL_NAME = None
 
 
 LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'standard': {
-            'format': "%(asctime)s %(levelname)s %(name)s: %(message)s",
-            'datefmt': '%m/%d/%Y %H:%M:%S'
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "standard": {
+            "format": "%(asctime)s %(levelname)s %(name)s: %(message)s",
+            "datefmt": "%m/%d/%Y %H:%M:%S",
         }
     },
-    'handlers': {
-        'default': {
-            'level': 'INFO',
-            'class': 'pupa.ext.ansistrm.ColorizingStreamHandler',
-            'formatter': 'standard'
+    "handlers": {
+        "default": {
+            "level": "INFO",
+            "class": "pupa.ext.ansistrm.ColorizingStreamHandler",
+            "formatter": "standard",
         },
     },
-    'loggers': {
-        '': {
-            'handlers': ['default'], 'level': 'DEBUG', 'propagate': True
-        },
-        'scrapelib': {
-            'handlers': ['default'], 'level': 'INFO', 'propagate': False
-        },
-        'requests': {
-            'handlers': ['default'], 'level': 'WARN', 'propagate': False
-        },
-        'boto': {
-            'handlers': ['default'], 'level': 'WARN', 'propagate': False
-        },
+    "loggers": {
+        "": {"handlers": ["default"], "level": "DEBUG", "propagate": True},
+        "scrapelib": {"handlers": ["default"], "level": "INFO", "propagate": False},
+        "requests": {"handlers": ["default"], "level": "WARN", "propagate": False},
+        "boto": {"handlers": ["default"], "level": "WARN", "propagate": False},
     },
 }


### PR DESCRIPTION
## Overview

A long time ago, in a galaxy far away, we used one scraper repository for many jurisdictional scrapers. These scrapers shared a pupa settings file that needed to account for some jurisdictions scraping into a plain OCD database, while others scraped into a Councilmatic database. Thus, we introduced a `SHARED_DB` environment variable that, if true, would include `councilmatic_core` in installed apps.

[The script we use to run scrapes sets the `SHARED_DB` variable](https://github.com/Metro-Records/la-metro-dashboard/blob/main/dags/scripts/targeted-scrape.sh), but it was not set for the pupa clean DAG, so the `councilmatic_core` app was not installed. This resulted in the deletion of top-level entities like organizations and people behaving badly, i.e., not cascading as configured in the Councilmatic app.

This PR does away with the conditional behavior in the settings file. The Metro scrapers are always running against a shared DB.

Connects https://github.com/datamade/django-councilmatic/issues/293

## Notes

Once this is merged and the main tag builds, we should be able to run the cleanup DAG on the staging dashboard without error.

## Testing Instructions

Ran locally against the staging database to confirm this works! 

```bash
docker run -it -e DATABASE_URL=${STAGING_DATABASE_URI} scrapers-lametro /bin/bash
# inside container
pupa clean
```