### PR TITLE
Allow for (strict) fuzzy match on body name when identifying minutes from OCR'ed document

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -602,8 +602,8 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
 
                             def edit_distance_lte_n(target, corpus, n):
                                 for line in corpus.splitlines():
-                                    _distance = distance(target, line)
-                                    self.debug(target, line, _distance)
+                                    _distance = distance(target, line, score_cutoff=n)
+                                    self.debug(f"{target}, {line}, {_distance}")
                                     if _distance <= n:
                                         self.debug("FOUND MATCH")
                                         return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ sentry-sdk
 freezegun==1.5.1
 pdfplumber==0.11.3
 pytesseract==0.3.10
+levenshtein


### PR DESCRIPTION
## Overview

This PR uses [edit distance](https://en.wikipedia.org/wiki/Edit_distance), of the number of insertions, deletions, or substitutions it would take to transform string A to string B, to fuzzy match on body name when identifying minutes files from OCR'ed text. This is necessary because the OCR operation is not perfect, so we may see misspellings like `regular board meetin` or `reqular board meeting` in the processed text.

This implementation allows for a maximum edit distance of 2, so it's pretty strict and should not lead to false positives, as the board and committee names are dissimilar enough. It also logs when we identify minutes via fuzzy match for easy debugging.

Related to https://github.com/Metro-Records/la-metro-councilmatic/issues/1201

## Testing Instructions

 Covered by test suite!