### PR TITLE
Explicitly skip events not in the web interface

### DIFF
--- a/lametro/events.py
+++ b/lametro/events.py
@@ -80,8 +80,11 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
             events = self.api_events(since_datetime=n_days_ago)
 
         public_events = filter(
-            lambda e: e.get("EventInSiteURL")
-            and self.head(e["EventInSiteURL"]).status_code == 200
+            (
+                lambda e: e.get("EventInSiteURL")
+                and self.head(e["EventInSiteURL"]).status_code == 200
+            ),
+            events,
         )
 
         service_councils = set(

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -79,6 +79,11 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
 
             events = self.api_events(since_datetime=n_days_ago)
 
+        public_events = filter(
+            lambda e: e.get("EventInSiteURL")
+            and self.head(e["EventInSiteURL"]).status_code == 200
+        )
+
         service_councils = set(
             sc["BodyId"]
             for sc in self.search(
@@ -86,7 +91,9 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
             )
         )
 
-        for event, web_event in PairedEventStream(events, find_missing_partner=True):
+        for event, web_event in PairedEventStream(
+            public_events, find_missing_partner=True
+        ):
             body_name = event["EventBodyName"]
 
             if "Board of Directors -" in body_name:

--- a/lametro/paired_event_stream.py
+++ b/lametro/paired_event_stream.py
@@ -105,7 +105,7 @@ class PairedEventStream:
     def unique_events(self) -> Generator[LAMetroAPIEvent, None, None]:
         last_key = None
 
-        for event in sorted(self.public_events, key=lambda e: e.own_key):
+        for event in sorted(self.events, key=lambda e: e.own_key):
             if event.own_key == last_key:
                 raise ValueError(
                     f"Found duplicate event key '{event.own_key}'. Skipping the following event...\n{event}."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 https://github.com/opencivicdata/pupa/archive/master.zip
 https://github.com/opencivicdata/python-legistar-scraper/archive/hcg/tweaks.zip
+https://github.com/datamade/scrapelib/archive/hcg/accept-response.zip
 django-councilmatic==3.2
 lxml
 sh 


### PR DESCRIPTION
## Overview

There are some private events (events in the API, but not the web interface) that violate our assumption about having only one event with the same name and date. Metro should fix recent / upcoming events, but it's not worth the trouble to have them update 8-year-old events. This PR adds logic to filter events that aren't viewable on InSite, which fixes the issue. 

### Notes

This should actually be implemented upstream in Python Legistar, but the class API would need a more serious overhaul than I want to do at the moment in order to facilitate it.

## Testing Instructions

 * Run the following command and confirm you get a no events returned exception: `docker compose run --rm scrapers pupa update lametro events event_ids=1271,1273 --rpm=0`
   * These events have a conflicting key but are also private, so should result in no error
 * Run a normal event scrape and confirm events are scraped: `docker compose run --rm scrapers pupa update lametro events window=0.05 --rpm=0`