### PR TITLE
Move event filtering into method, fire before pairing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,4 +4,4 @@ exclude =
 # So flake8 plays nicely with black
 # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html
 max-line-length = 100
-extend-ignore = E203
+extend-ignore = E203 E731


### PR DESCRIPTION
## Overview

This PR moves all event filtering (service councils, public events) into a method and applies the method to events before pairing.

Extension of #43 

## Testing Instructions

 * Run a windowed scrape and a targeted event scrape and confirm you get the results you expect.