### PR TITLE
Scrape Special Board Member Workshop

### DIFF
--- a/lametro/people.py
+++ b/lametro/people.py
@@ -127,9 +127,11 @@ class LametroPersonScraper(LegistarAPIPersonScraper, Scraper):
                 body_types["Independent Taxpayer Oversight Committee"],
             ]
 
-            if (body["BodyTypeId"] in body_types_list) or (
-                "test" in body["BodyName"].lower()
-            ):
+            is_committee = body["BodyTypeId"] in body_types_list
+            is_test_body = "test" in body["BodyName"].lower()
+            is_board_workshop = body["BodyName"] == "Special Board Member Workshop"
+
+            if is_committee or is_test_body or is_board_workshop:
                 organization_name = body["BodyName"].strip()
 
                 o = Organization(


### PR DESCRIPTION
## Overview

This PR fixes a bill scraper error where a board report with an action associated with `Special Board Member Workshop` couldn't be scraped. The fix was to add make sure the people scraper captured that org. 

Connects Metro-Records/la-metro-councilmatic#1245

## Testing Instructions

 * Run a person scrape with `docker-compose run --rm scrapers pupa update lametro people --rpm=0`
 * Run a bill scrape with `docker-compose run --rm scrapers pupa update lametro bills matter_ids=11277 --rpm=0` (the offending bill is [here](https://webapi.legistar.com/v1/metro/matters/11277))

