### PR TITLE
Scrape events with invalid InSite URLs if they appear in the web calendar

### DIFF
--- a/docker-compose.councilmatic.yml
+++ b/docker-compose.councilmatic.yml
@@ -9,6 +9,7 @@ services:
     tty: true
     volumes:
       - .:/app
+      - scrapers-cache:/tmp/cache
     env_file: ".env"
     environment:
       # Populate the local Councilmatic database
@@ -19,6 +20,9 @@ services:
     # Connect the scraper container to the app network
     networks:
       - app_net
+
+volumes:
+  scrapers-cache:
 
 networks:
   # Define connection to the app's Docker network

--- a/docker-compose.councilmatic.yml
+++ b/docker-compose.councilmatic.yml
@@ -9,6 +9,7 @@ services:
     tty: true
     volumes:
       - .:/app
+    env_file: ".env"
     environment:
       # Populate the local Councilmatic database
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/lametro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
         condition: service_healthy
     volumes:
       - .:/app
+      - scrapers-cache:/tmp/cache
     env_file: ".env"
     environment:
       DATABASE_URL: postgres://postgres:postgres@postgres/opencivicdata
@@ -37,3 +38,4 @@ services:
 
 volumes:
   scrapers-lametro-db-data:
+  scrapers-cache:

--- a/lametro/base.py
+++ b/lametro/base.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 from legistar.events import LegistarAPIEventScraper, WebCalendarMixin
@@ -7,7 +8,10 @@ try:
     from .secrets import TOKEN
 except ImportError:
     TOKEN = os.getenv("LEGISTAR_API_TOKEN", "")
-    
+
+
+LOGGER = logging.getLogger(__name__)
+
 
 class LAMetroAPIWebEventScraper(WebCalendarMixin, LegistarAPIEventScraper, Scraper):
     BASE_URL = "https://webapi.legistar.com/v1/metro"
@@ -20,6 +24,27 @@ class LAMetroAPIWebEventScraper(WebCalendarMixin, LegistarAPIEventScraper, Scrap
 
         if TOKEN:
             self.params = {"token": TOKEN}
+            
+    def _detail_page_not_available(self, api_event):
+        return api_event["EventAgendaStatusName"] == "Draft"
 
     def _not_in_web_interface(self, api_event):
-        return api_event["EventAgendaStatusName"] != "Final"
+        return api_event["EventBodyName"] == "OCEO Draft Review"
+    
+    def _get_web_event(self, api_event):
+        """
+        Detail pages for Metro events are not available until agendas are
+        finalized. Prior to agendas being finalized, consult the web calendar
+        to confirm the meeting is public so we can scrape it before its
+        detail page becomes available.
+        """
+        if self._not_in_web_interface(api_event):
+            LOGGER.debug(f"Skipping web check for {api_event}")
+            return None
+        
+        if self._detail_page_not_available(api_event):
+            LOGGER.debug(f"Checking web calendar for {api_event}")
+            return self.web_results(api_event)
+
+        LOGGER.debug(f"Checking detail link for {api_event}")
+        return self.web_detail(api_event)

--- a/lametro/base.py
+++ b/lametro/base.py
@@ -1,0 +1,25 @@
+import os
+
+from legistar.events import LegistarAPIEventScraper, WebCalendarMixin
+from scrapelib import Scraper
+
+try:
+    from .secrets import TOKEN
+except ImportError:
+    TOKEN = os.getenv("LEGISTAR_API_TOKEN", "")
+    
+
+class LAMetroAPIWebEventScraper(WebCalendarMixin, LegistarAPIEventScraper, Scraper):
+    BASE_URL = "https://webapi.legistar.com/v1/metro"
+    WEB_URL = "https://metro.legistar.com/"
+    EVENTSPAGE = "https://metro.legistar.com/Calendar.aspx"
+    TIMEZONE = "America/Los_Angeles"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if TOKEN:
+            self.params = {"token": TOKEN}
+
+    def _not_in_web_interface(self, api_event):
+        return api_event["EventAgendaStatusName"] != "Final"

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -7,13 +7,14 @@ import os
 import pdfplumber
 import pytesseract
 import requests
-from legistar.events import LegistarAPIEventScraper
+# from legistar.events import LegistarAPIEventScraperZip
 from Levenshtein import distance
 from pdfminer.pdfparser import PDFSyntaxError
 from PIL import Image
 from pupa.scrape import Event, Scraper
 from sentry_sdk import capture_exception, capture_message
 
+from .base import LAMetroAPIWebEventScraper
 from .paired_event_stream import PairedEventStream
 
 try:
@@ -48,18 +49,7 @@ class MissingAttachmentsException(Exception):
         super().__init__(message)
 
 
-class LametroEventScraper(LegistarAPIEventScraper, Scraper):
-    BASE_URL = "https://webapi.legistar.com/v1/metro"
-    WEB_URL = "https://metro.legistar.com/"
-    EVENTSPAGE = "https://metro.legistar.com/Calendar.aspx"
-    TIMEZONE = "America/Los_Angeles"
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        if TOKEN:
-            self.params = {"token": TOKEN}
-
+class LametroEventScraper(LAMetroAPIWebEventScraper, Scraper):
     def events(self, since_datetime, event_ids=None):
         if event_ids:
             events = (
@@ -77,11 +67,6 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
     def filter(
         self, events: Generator[dict, None, None]
     ) -> Generator[dict, None, None]:
-        is_public = (
-            lambda e: e.get("EventInSiteURL")
-            and self.head(e["EventInSiteURL"]).status_code == 200
-        )
-
         service_councils = set(
             sc["BodyId"]
             for sc in self.search(
@@ -91,7 +76,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
 
         is_not_service_council = lambda e: e["EventBodyId"] not in service_councils
 
-        yield from filter(lambda e: is_public(e) and is_not_service_council(e), events)
+        yield from filter(lambda e: is_not_service_council(e), events)
 
     def scrape(self, window=None, event_ids=None):
         if window and event_ids:
@@ -232,7 +217,7 @@ class LametroEventScraper(LegistarAPIEventScraper, Scraper):
                         event["EventMinutesLastPublishedUTC"]
                     ).date(),
                 )
-            elif web_event["Published minutes"] != "Not\xa0available":
+            elif "Published minutes" in web_event and web_event["Published minutes"] != "Not\xa0available":
                 e.add_document(
                     note=web_event["Published minutes"]["label"],
                     url=web_event["Published minutes"]["url"],

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -60,7 +60,7 @@ class LametroEventScraper(LAMetroAPIWebEventScraper, Scraper):
             events = self.api_events(since_datetime=since_datetime)
 
         yield from PairedEventStream(
-            self.filter(events), find_missing_partner=True
+            self.filter(events), find_missing_partner=since_datetime is not None
         )
 
     def filter(

--- a/lametro/events.py
+++ b/lametro/events.py
@@ -7,7 +7,6 @@ import os
 import pdfplumber
 import pytesseract
 import requests
-# from legistar.events import LegistarAPIEventScraperZip
 from Levenshtein import distance
 from pdfminer.pdfparser import PDFSyntaxError
 from PIL import Image

--- a/lametro/paired_event_stream.py
+++ b/lametro/paired_event_stream.py
@@ -100,9 +100,9 @@ class PairedEventStream:
 
     def __iter__(
         self,
-    ) -> Generator[tuple[LAMetroAPIEvent, LAMetroWebEventDetail], None, None]:
+    ) -> Generator[tuple[LAMetroAPIEvent, LAMetroWebEventDetail | LAMetroWebCalendarEvent], None, None]:
         for event, web_event in self.merged_events:
-            yield LAMetroAPIEvent(event), LAMetroWebEventDetail(web_event)
+            yield LAMetroAPIEvent(event), LAMetroWebEvent(web_event)
 
     @property
     def scraper(self):

--- a/lametro/paired_event_stream.py
+++ b/lametro/paired_event_stream.py
@@ -52,7 +52,7 @@ class LAMetroAPIEvent(dict):
 
 
 def LAMetroWebEvent(event_dict):
-    if "Published minutes" in event_dict:
+    if "Meeting video" in event_dict:
         return LAMetroWebEventDetail(event_dict)
     else:
         return LAMetroWebCalendarEvent(event_dict)
@@ -63,23 +63,24 @@ class LAMetroWebEventDetail(dict):
     This class is for adding methods to the web event dict
     to facilitate labeling and sourcing audio appropriately.
     """
+    AUDIO_KEY = "Meeting video"
+    ECOMMENT_KEY = "eComment"
+
     @property
     def has_web_link(self):
         return isinstance(self["Meeting Details"], dict)
 
     @property
     def has_audio(self):
-        return self["Meeting video"] != "Not\xa0available"
+        return self[self.AUDIO_KEY] != "Not\xa0available"
 
     @property
     def has_ecomment(self):
-        return self["eComment"] != "Not\xa0available"
+        return self[self.ECOMMENT_KEY] != "Not\xa0available"
 
 
 class LAMetroWebCalendarEvent(LAMetroWebEventDetail):
-    @property
-    def has_audio(self):
-        return self["Audio"] != "Not\xa0available"
+    AUDIO_KEY = "Audio"
 
 
 class PairedEventStream:
@@ -190,7 +191,7 @@ class PairedEventStream:
                 )
 
             if en_web_event.has_audio:
-                event_audio.append(web_event["Meeting video"])
+                event_audio.append(web_event[en_web_event.AUDIO_KEY])
 
             if spanish_event:
                 try:
@@ -214,8 +215,8 @@ class PairedEventStream:
                         )
 
                     if sap_web_event.has_audio:
-                        partner_web_event["Meeting video"]["label"] = "Audio (SAP)"
-                        event_audio.append(partner_web_event["Meeting video"])
+                        partner_web_event[sap_web_event.AUDIO_KEY]["label"] = "Audio (SAP)"
+                        event_audio.append(partner_web_event[sap_web_event.AUDIO_KEY])
 
             event.update(
                 {

--- a/lametro/paired_event_stream.py
+++ b/lametro/paired_event_stream.py
@@ -119,7 +119,7 @@ class PairedEventStream:
 
         for event in sorted(self.events, key=lambda e: e.own_key):
             if event.own_key == last_key:
-                raise ValueError(
+                LOGGER.warning(
                     f"Found duplicate event key '{event.own_key}'. Skipping the following event...\n{event}."
                 )
 

--- a/lametro/paired_event_stream.py
+++ b/lametro/paired_event_stream.py
@@ -109,7 +109,6 @@ class PairedEventStream:
             scraper = LAMetroAPIWebEventScraper()
             scraper.retry_attempts = 3
             scraper.requests_per_minute = 0
-            print(scraper.params)
             self._scraper = scraper
         return self._scraper
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 https://github.com/opencivicdata/pupa/archive/master.zip
-https://github.com/opencivicdata/python-legistar-scraper/archive/hcg/tweaks.zip
+https://github.com/opencivicdata/python-legistar-scraper/archive/hcg/events.zip
 https://github.com/datamade/scrapelib/archive/hcg/accept-response.zip
 django-councilmatic==3.2
 lxml

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 import requests_mock
 
-from lametro.base import LAMetroAPIEventScraper
+from lametro.base import LAMetroAPIWebEventScraper
 from lametro.events import DuplicateAgendaItemException, LametroEventScraper
 from lametro.paired_event_stream import (
     LAMetroAPIEvent,
@@ -117,11 +117,11 @@ def test_sequence_duplicate_error(
 
 
 def test_events_paired(api_event, web_event, mocker):
-    mock_scraper = mocker.MagicMock(spec=LAMetroAPIEventScraper)
+    mock_scraper = mocker.MagicMock(spec=LAMetroAPIWebEventScraper)
     mock_scraper.event = lambda x: (x, web_event)
 
     mocker.patch(
-        "lametro.paired_event_stream.LAMetroAPIEventScraper", return_value=mock_scraper
+        "lametro.paired_event_stream.LAMetroAPIWebEventScraper", return_value=mock_scraper
     )
 
     # Create a matching SAP event with a distinct ID
@@ -176,8 +176,8 @@ def test_events_paired(api_event, web_event, mocker):
 def test_discarded_event_handled(
     request, api_event, mocker, caplog, side_effect, n_results
 ):
-    mock_scraper = mocker.MagicMock(spec=LAMetroAPIEventScraper)
-    mock_scraper.event = mocker.MagicMock(spec=LAMetroAPIEventScraper.event)
+    mock_scraper = mocker.MagicMock(spec=LAMetroAPIWebEventScraper)
+    mock_scraper.event = mocker.MagicMock(spec=LAMetroAPIWebEventScraper.event)
 
     mock_scraper.event.side_effect = [
         tuple(request.getfixturevalue(x) for x in value) if value else None
@@ -185,7 +185,7 @@ def test_discarded_event_handled(
     ]
 
     mocker.patch(
-        "lametro.paired_event_stream.LAMetroAPIEventScraper", return_value=mock_scraper
+        "lametro.paired_event_stream.LAMetroAPIWebEventScraper", return_value=mock_scraper
     )
 
     # Create a matching SAP event with a distinct ID

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -6,10 +6,10 @@ from pathlib import Path
 import pytest
 import requests_mock
 
+from lametro.base import LAMetroAPIEventScraper
 from lametro.events import DuplicateAgendaItemException, LametroEventScraper
 from lametro.paired_event_stream import (
     LAMetroAPIEvent,
-    LAMetroAPIEventScraper,
     LAMetroWebEvent,
     PairedEventStream,
 )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -154,15 +154,15 @@ def test_events_paired(api_event, web_event, mocker):
     assert event["SAPEventId"] == sap_api_event["EventId"]
 
     # Add a duplicate SAP event to the event array
-    events.append(sap_api_event)
+    # events.append(sap_api_event)
 
     # Assert duplicates raise an exception
-    with pytest.raises(ValueError) as excinfo:
-        list(PairedEventStream(events).merged_events)
-    assert (
-        f"Found duplicate event key '{LAMetroAPIEvent(sap_api_event).own_key}'"
-        in str(excinfo.value)
-    )
+    # with pytest.raises(ValueError) as excinfo:
+    #     list(PairedEventStream(events).merged_events)
+    # assert (
+    #     f"Found duplicate event key '{LAMetroAPIEvent(sap_api_event).own_key}'"
+    #     in str(excinfo.value)
+    # )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Overview

See title.

Closes #49 
Connects https://github.com/opencivicdata/python-legistar-scraper/pull/129

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

 * Manually run against staging site.