### PR TITLE
Account for events removed from legistar

### DIFF
--- a/lametro/paired_event_stream.py
+++ b/lametro/paired_event_stream.py
@@ -174,7 +174,7 @@ class PairedEventStream:
             event_audio = []
             try:
                 event, web_event = self.scraper.event(english_event)
-            except (ValueError, TypeError) as e:
+            except (ValueError, TypeError, IndexError) as e:
                 LOGGER.warning(
                     f"English event discarded by base scraper due to the following error: {e}"
                 )
@@ -196,7 +196,7 @@ class PairedEventStream:
             if spanish_event:
                 try:
                     partner, partner_web_event = self.scraper.event(spanish_event)
-                except (ValueError, TypeError):
+                except (ValueError, TypeError, IndexError):
                     LOGGER.warning(
                         "Spanish event discarded by base scraper. Skipping merge..."
                     )


### PR DESCRIPTION
## Overview

The scraper was failing today because of an event that was removed from legistar. Here is a link for this event:
https://metro.legistar.com/MeetingDetail.aspx?LEGID=3320&GID=557&G=A5FAA737-A54D-4A6C-B1E8-FF70F765FA94

## Testing Instructions

 * Pull down this branch and build the container if needed
 * Using the [instructions in the quarto docs](https://metro-records.github.io/scrapers-lametro/local-development.html#populate-a-local-councilmatic-instance), bring your local councilmatic instance up, and run this command from your scrapers directory:
```bash
docker compose -f docker-compose.councilmatic.yml run --rm scrapers pupa update lametro event window=60 --rpm=0
```
 * Confirm that the command ran without error, but still printed the `list index out of range` warning to the console