### PR TITLE
Capture controlling body data from API response

### DIFF
--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -228,6 +228,7 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
             date = matter["MatterIntroDate"]
             title = matter["MatterTitle"]
             identifier = matter["MatterFile"]
+            body = matter["MatterBodyName"]
 
             is_board_correspondence = matter["MatterTypeName"] in {
                 "Board Box",
@@ -268,7 +269,7 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
                 legislative_session=bill_session,
                 title=title,
                 classification=bill_type,
-                from_organization={"name": "Board of Directors"},
+                from_organization=body,
             )
 
             # The Metro scraper scrapes private bills.


### PR DESCRIPTION
## Overview

This PR uses `MatterBodyName` from the API response to set `from_organization` for bills.

- `from_organization` is used to set `controlling_body` in Metro-Records/la-metro-councilmatic
- Per [LAMetro](https://github.com/Metro-Records/la-metro-councilmatic/issues/1297#issuecomment-4382290537), MatterBodyName is the controlling body

Connects [#1297](https://github.com/Metro-Records/la-metro-councilmatic/issues/1297)

### Notes

No institutional memory of why we had previously hardcoded `from_organization` to
"Board of Directors", nor any known reason why it should stay. [see Slack](https://datamade.slack.com/archives/CJPTKSY9X/p1780427418157389?thread_ts=1780415299.685849&cid=CJPTKSY9X)