### PR TITLE
Fix MatterBodyName scraping

### DIFF
--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -229,6 +229,12 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
             title = matter["MatterTitle"]
             identifier = matter["MatterFile"]
             body = matter["MatterBodyName"]
+            
+            if body in (
+                    "Board of Directors - Regular Board Meeting",
+                    "Board of Directors - Special Board Meeting",
+            ):
+                body = "Board of Directors"
 
             is_board_correspondence = matter["MatterTypeName"] in {
                 "Board Box",

--- a/lametro/bills.py
+++ b/lametro/bills.py
@@ -269,7 +269,7 @@ class LametroBillScraper(LegistarAPIBillScraper, Scraper):
                 legislative_session=bill_session,
                 title=title,
                 classification=bill_type,
-                from_organization=body,
+                from_organization={"name": body},
             )
 
             # The Metro scraper scrapes private bills.


### PR DESCRIPTION
## Overview

Fix how MatterBodyName is captured, so that it can be parsed correctly by the pupa importer. Also make sure to normalize "Board of Directors" meeting names.

Wraps organization name in dict because `resolve_json_id` from the pupa base importer wants this. This is also how the hardcoded value was previously formatted:  `from_organization:{"name": "Board of Directors"}`

Corrects #62 and resolves #67

## Notes

Now LA Metro Bill sponsors, controlling body, and actions all normalize the meeting name "Board of Directors - Regular Board Meeting" (and sometimes "Board of Directors - Special Board Meeting") to "Board of Directors" to associate it with the correct organization. And they all do this separately inside themselves. 

Should this get consolidated somewhere? Perhaps somewhere that guarantees any additional organizational fields that get added / modified will perform this operation before attempting to resolve the organization id, instead of requiring you to remember to call this special normalization method?

## Testing Instructions

You can use this command for a bill that contains the organization in the original error, though the error should not be organization specific. See [matter 12614](https://webapi.legistar.com/v1/metro/matters/12614)
``` shell
docker compose run --rm scrapers pupa update lametro bills matter_ids=12614
```

Except in the case of Board of Directors, due to the necessary normalization
See [matter 12357](https://webapi.legistar.com/v1/metro/matters/12357)
``` shell
docker compose run --rm scrapers pupa update lametro bills matter_ids=12357
```

Try to run the bill scrapes with and without the fix.